### PR TITLE
Fix broken Depsy link in profile

### DIFF
--- a/static/src/person-page/person-page.tpl.html
+++ b/static/src/person-page/person-page.tpl.html
@@ -118,7 +118,7 @@
                             <a href="http://orcid.org/{{ person.orcid_id }}">
                                 <img src="static/img/favicons/orcid.ico" alt="">
                             </a>
-                            <a href="http://depsy.org/{{ person.depsy_id }}"
+                            <a href="http://depsy.org/person/{{ person.depsy_id }}"
                                     ng-show="person.depsy_id">
                                 <img src="static/img/favicons/depsy.png" alt="">
                             </a>


### PR DESCRIPTION
The user profile was linking to depsy using `http://depsy.org/{{ person.depsy_id }}` instead of `http://depsy.org/person/{{ person.depsy_id }}`.

Fixes #2

I'm not  sure if this really fixes the issue as I did not try running the app on my machine (not sure if that would work). A search of the repo revealed that this was the only place where the `http://depsy.org/` domain showed up in the code of the user profile. Any help testing this would be great!

Congratulations on a great product!